### PR TITLE
fix: expand default snapshot process states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ Behavior:
 - emits coverage report (`reports/snapshot-coverage/...`)
 - supports same-source skip-rebuild via source fingerprint (`count + max(modified_at) + config`)
 - process selection supports:
-  - `--process-states <csv|all>` for `state_code` filtering
+  - `--process-states <csv|all>` for `state_code` filtering (default runtime scope: `100..=199`)
   - `--include-user-id <uuid>` to include one user's processes in addition to `process-states` (OR union)
 - provider matching supports:
   - `strict_unique_provider` (legacy strict behavior)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ psql "$CONN" -v ON_ERROR_STOP=1 -f supabase/migrations/20260309042000_lca_latest
 
 默认就是“全库正式版”：
 
-- 只取 `state_code=100`（`--process-states` 默认 `100`）
+- 默认纳入 `state_code=100~199`（`--process-states` 默认覆盖 `100,101,...,199`）
 - 不限 process 数量（`--process-limit` 默认 `0`，即 no limit）
 - 生成 coverage 报表到 `reports/snapshot-coverage/<snapshot_id>.{json,md}`
 - 报表包含：匹配率、奇异风险、矩阵规模、build 分阶段耗时

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -57,7 +57,7 @@ struct Cli {
     s3_prefix: String,
     #[arg(long)]
     snapshot_id: Option<Uuid>,
-    #[arg(long, default_value = "100")]
+    #[arg(long, default_value_t = solver_worker::default_snapshot_process_states_arg())]
     process_states: String,
     #[arg(long)]
     include_user_id: Option<Uuid>,
@@ -2794,8 +2794,8 @@ mod tests {
     use super::{
         AllocationMode, ExchangeDirection, NormalizationMode, ParsedExchange, ProcessMeta,
         ProviderRule, add_technosphere_edge, biosphere_gross_value, geo_score,
-        resolve_allocation_fraction, resolve_multi_provider, resolve_reference_normalization,
-        time_score,
+        parse_process_states, resolve_allocation_fraction, resolve_multi_provider,
+        resolve_reference_normalization, time_score,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -2840,6 +2840,29 @@ mod tests {
             ProviderRule::parse("split_equal").expect("parse"),
             ProviderRule::SplitEqual
         );
+    }
+
+    #[test]
+    fn default_process_states_cover_100_through_199() {
+        let default_states = solver_worker::default_snapshot_process_states_arg();
+        let (all_states, parsed, label) =
+            parse_process_states(default_states.as_str()).expect("parse default states");
+
+        assert!(!all_states);
+        assert_eq!(parsed.len(), 100);
+        assert_eq!(parsed.first().copied(), Some(100));
+        assert_eq!(parsed.last().copied(), Some(199));
+        assert_eq!(label, default_states);
+    }
+
+    #[test]
+    fn explicit_process_states_still_override_default_scope() {
+        let (all_states, parsed, label) =
+            parse_process_states("100,150,199").expect("parse explicit states");
+
+        assert!(!all_states);
+        assert_eq!(parsed, vec![100, 150, 199]);
+        assert_eq!(label, "100,150,199");
     }
 
     #[test]

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -1327,7 +1327,10 @@ async fn run_snapshot_builder_job(
         "--snapshot-id".to_owned(),
         snapshot_id.to_string(),
         "--process-states".to_owned(),
-        process_states.unwrap_or("100").to_owned(),
+        process_states.map_or_else(
+            crate::default_snapshot_process_states_arg,
+            ToOwned::to_owned,
+        ),
         "--provider-rule".to_owned(),
         provider_rule.unwrap_or("strict_unique_provider").to_owned(),
         "--reference-normalization-mode".to_owned(),

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -1,5 +1,16 @@
 //! Worker crate library modules shared by binaries.
 
+pub const DEFAULT_SNAPSHOT_PROCESS_STATE_START: i32 = 100;
+pub const DEFAULT_SNAPSHOT_PROCESS_STATE_END: i32 = 199;
+
+#[must_use]
+pub fn default_snapshot_process_states_arg() -> String {
+    (DEFAULT_SNAPSHOT_PROCESS_STATE_START..=DEFAULT_SNAPSHOT_PROCESS_STATE_END)
+        .map(|state| state.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 pub mod artifacts;
 pub mod config;
 pub mod contribution_path;

--- a/crates/solver-worker/src/snapshot_artifacts.rs
+++ b/crates/solver-worker/src/snapshot_artifacts.rs
@@ -286,7 +286,7 @@ mod tests {
     fn encode_decode_snapshot_artifact_roundtrip() {
         let snapshot_id = uuid::Uuid::new_v4();
         let config = SnapshotBuildConfig {
-            process_states: "100".to_owned(),
+            process_states: crate::default_snapshot_process_states_arg(),
             include_user_id: None,
             process_limit: 0,
             provider_rule: "strict_unique_provider".to_owned(),

--- a/scripts/build_snapshot_from_ilcd.sh
+++ b/scripts/build_snapshot_from_ilcd.sh
@@ -38,7 +38,7 @@ Usage:
 
 Options:
   --snapshot-id <uuid>         explicit snapshot id (default: auto generated)
-  --process-states <csv|all>   process state_code filter, use "all" to disable filter (default: "100")
+  --process-states <csv|all>   process state_code filter, use "all" to disable filter (default: "100,101,...,199")
   --include-user-id <uuid>     include processes from this user_id in addition to --process-states
   --process-limit <n>          limit processes for debug snapshot, 0 = no limit (default: 0)
   --provider-rule <rule>       provider matching rule (default: strict_unique_provider)


### PR DESCRIPTION
Closes Neo9281/tiangong-lca-calculator#5

## Summary
- Expand the calculator snapshot builder default process-state scope from only state_code 100 to the full 100-199 range.
- Keep explicit --process-states overrides unchanged and update the worker auto-build path, docs, and regression coverage to use the same shared default source.

## Key Decisions
- Centralized the default snapshot process-state list in solver-worker so the CLI default and the auto-build invocation path cannot drift.
- Did not change the existing explicit state-code parsing or SQL filtering semantics; this patch only widens the default scope when callers omit --process-states.

## Validation
- cargo fmt --all -- --check
- cargo test -p solver-worker process_states
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings

## Risks / Rollback
- Low risk: only the default snapshot candidate scope changes, while explicit state-code filters still behave as before.

## Workspace Integration
- After merge, lca-workspace still needs a later submodule pointer bump before delivery is fully complete.